### PR TITLE
Add modulefiles for using payu environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
     environment: ${{ matrix.deployment-environment }}
     env:
       NAME: ${{ needs.pack.outputs.name }}
+      VERSION: ${{ needs.pack.outputs.version }}
     steps:
       - uses: actions/download-artifact@v3.0.2
         with:
@@ -89,7 +90,7 @@ jobs:
 
       - name: Deploy to ${{ matrix.deployment-environment }}
         env:
-          PAYU_ENVIRONMENT_LOCATION: ${{ vars.DEPLOYMENT_LOCATION }}/${{ env.NAME }}
+          PAYU_ENVIRONMENT_LOCATION: ${{ vars.DEPLOYMENT_LOCATION }}/${{ env.VERSION }}
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           mkdir ${{ env.PAYU_ENVIRONMENT_LOCATION }}
@@ -100,14 +101,15 @@ jobs:
           source ${{ env.PAYU_ENVIRONMENT_LOCATION }}/bin/activate
           payu --version
           source ${{ env.PAYU_ENVIRONMENT_LOCATION }}/bin/deactivate
+          ln -s ${{ env.MODULE_LOCATION }}/.common ${{ env.MODULE_LOCATION }}/${{ env.VERSION }}
           EOT
 
       # Release
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15
         with:
-          tag_name: ${{ needs.pack.outputs.version }}
-          name: Payu ${{ needs.pack.outputs.version }}
+          tag_name: ${{ env.VERSION }}
+          name: Payu ${{ env.VERSION }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/update-module.yml
+++ b/.github/workflows/update-module.yml
@@ -1,6 +1,8 @@
 name: Update common modulefiles on Gadi
 on:
-  push: 
+  push:
+    branches:
+      - main
     paths:
       - 'modules/**'
 jobs:

--- a/.github/workflows/update-module.yml
+++ b/.github/workflows/update-module.yml
@@ -1,0 +1,24 @@
+name: Update common modulefiles on Gadi
+on:
+  push: 
+    paths:
+      - 'modules/**'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: Gadi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: access-nri/actions/.github/actions/setup-ssh@main
+        id: ssh
+        with:
+          hosts: |
+            ${{ secrets.HOST_DATA }}
+          private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Copy modulefiles to Gadi
+        run: |
+          rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \ 
+            modules/  \
+            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.MODULE_LOCATION }}

--- a/modules/.common
+++ b/modules/.common
@@ -1,0 +1,48 @@
+#%Module1.0
+
+# This is adapted from hh5's modulefiles for activating conda environments
+# using modules (see /g/data/hh5/public/modules/conda/.common.v2)
+
+module-whatis {Activate Payu's micromamba environment}
+conflict payu
+
+# Name of this module's environment, e.g. payu/VERSION
+set payuname [module-info name]
+
+# Get the environment variables from activate script
+set payuenv [exec /bin/env -i /g/data/vk83/modules/payu/env.sh $payuname]
+
+# Convert the environment into module commands
+set lines [split $payuenv '\n']
+foreach line $lines {
+    regexp {^([^=]*)=(.*)} $line -> key value
+
+    # Exclude $PWD and $_
+    if {[lsearch -exact {MODULEPATH PWD _} $key] >= 0} {
+        continue
+    }
+
+    # Is this some sort of path?
+    if {[string match UDUNITS2_XML_PATH $key]} {
+        # This is actually a single path
+        setenv $key $value
+        continue
+    } elseif {[string match *?PATH $key]} {
+        # A *PATH variable to be prepended with a ':'
+        prepend-path $key $value
+        continue
+    } elseif {[lsearch {_LMFILES_ LOADEDMODULES} $key] >= 0} {
+        # Modulefile stuff that works like a path
+        prepend-path $key $value
+        continue
+    } elseif {[string match PATH $key]} {
+        # PATH itself (strip out the system paths to keep ordering correct)
+        prepend-path $key [regsub {:/usr/bin:/bin} $value {}]
+        continue
+    }
+
+    # Otherwise set an environment var
+    setenv $key $value
+}
+
+setenv LC_ALL en_AU.utf8

--- a/modules/env.sh
+++ b/modules/env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Prints the environment variables when activating un-packed payu environment
+export PATH=/usr/bin:/bin
+source /g/data/vk83/apps/$1/bin/activate
+/bin/env


### PR DESCRIPTION
- Add common modulefiles for activating payu environments
- Add workflow for copying common modulefiles to Gadi
- Add modulefile symlink to payu deployment workflow

This has been implemented similar to `hh5`'s `conda` environments as described in #4