### PR TITLE
Updated deployment environment to 1.0.30

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
 dependencies:
   # note that the deployment requires a specific version of 'accessnri::payu' to run
-  - accessnri::payu==1.0.29
+  - accessnri::payu==1.0.30
   - coecms::f90nml
   - conda-lock
   - conda-pack


### PR DESCRIPTION
Deploy `Payu 1.0.30` to Gadi. 
Release notes for this version are here: https://github.com/payu-org/payu/releases/tag/1.0.30