### PR TITLE
Add conda-unpack to clean up path pre-fixes inside environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,7 @@ jobs:
           fi
           tar -xzf ${{ vars.PACK_LOCATION }}/${{ env.NAME }}.tar.gz -C ${{ env.PAYU_ENVIRONMENT_LOCATION }}
           source ${{ env.PAYU_ENVIRONMENT_LOCATION }}/bin/activate
+          conda-unpack
           payu --version
           source ${{ env.PAYU_ENVIRONMENT_LOCATION }}/bin/deactivate
           ln -s ${{ vars.MODULE_LOCATION }}/.common ${{ vars.MODULE_LOCATION }}/${{ env.VERSION }}


### PR DESCRIPTION
Run `conda-unpack` inside unpacked environment to clean up any pre-fixes inside environment.

This fixes an error of running `git fetch/clone` with remote repositories as it wasn't able to find paths to key git-https libs/exe. 

