### PR TITLE
Update env-dev.yml: Add cftime dependency

### DIFF
--- a/env-dev.yml
+++ b/env-dev.yml
@@ -15,3 +15,4 @@ dependencies:
   - nco
   - pytest
   - openssh>=8.3
+  - cftime


### PR DESCRIPTION
Add cftime dependency to dev environment file so conda handles the cftime install with a compatible version of numpy (one of cftime's dependencies) before payu is installed by pip. Closes #28 

Using pip install of payu main branch seems to install incompatible versions of numpy and cftime? I don't fully understand how as when installing `pip install payu` in python virtual environments (python3.11), it seems to run fine.