### PR TITLE
Update python to 3.10 in payu dev environment

### DIFF
--- a/env-dev.yml
+++ b/env-dev.yml
@@ -3,7 +3,7 @@ channels:
   - accessnri
   - conda-forge
 dependencies:
-  - python>=3.10
+  - python==3.10
   # Use latest changes from payu's master branch
   - pip:
     - git+https://github.com/payu-org/payu.git@master

--- a/env-dev.yml
+++ b/env-dev.yml
@@ -1,14 +1,13 @@
 name: payu-dev
 channels:
   - accessnri
-  - coecms
   - conda-forge
 dependencies:
   - python>=3.10
   # Use latest changes from payu's master branch
   - pip:
     - git+https://github.com/payu-org/payu.git@master
-  - coecms::f90nml
+  - f90nml
   - conda-lock
   - conda-pack
   - gh

--- a/env-dev.yml
+++ b/env-dev.yml
@@ -4,6 +4,7 @@ channels:
   - coecms
   - conda-forge
 dependencies:
+  - python>=3.10
   # Use latest changes from payu's master branch
   - pip:
     - git+https://github.com/payu-org/payu.git@master


### PR DESCRIPTION
The payu environments are currently use Python 3.9 as that is the default (see #32) . This PR is updating the python version in the development environment to use `python>=3.10`. Should the python version be fixed, e.g `python=3.10`?