### PR TITLE
Update env.yaml to payu 1.1.4, python 3.10 and conda-forge f90nml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,12 +1,12 @@
 name: payu
 channels:
   - accessnri
-  - coecms
   - conda-forge
 dependencies:
+  - python==3.10
   # note that the deployment requires a specific version of 'accessnri::payu' to run
-  - accessnri::payu==1.1.3
-  - coecms::f90nml
+  - accessnri::payu==1.1.4
+  - f90nml
   - conda-lock
   - conda-pack
   - gh

--- a/env.yml
+++ b/env.yml
@@ -2,10 +2,12 @@ name: payu
 channels:
   - accessnri
   - conda-forge
+  - coecms
 dependencies:
   - python==3.10
   # note that the deployment requires a specific version of 'accessnri::payu' to run
   - accessnri::payu==1.1.4
+  - coecms::yamanifest
   - f90nml
   - conda-lock
   - conda-pack

--- a/env.yml
+++ b/env.yml
@@ -1,13 +1,13 @@
 name: payu
 channels:
   - accessnri
-  - conda-forge
   - coecms
+  - conda-forge
 dependencies:
   - python==3.10
   # note that the deployment requires a specific version of 'accessnri::payu' to run
   - accessnri::payu==1.1.4
-  - coecms::yamanifest
+  - yamanifest
   - f90nml
   - conda-lock
   - conda-pack


### PR DESCRIPTION
Deploy a new version of payu environment with `payu` version 1.1.4, `python` 3.10 (was 3.9 by default) and use `f90nml` from `conda-forge` channel

Closes #33, #30 