### PR TITLE
Add mule dependency to payu/dev environment

### DIFF
--- a/env-dev.yml
+++ b/env-dev.yml
@@ -7,6 +7,7 @@ dependencies:
   # Use latest changes from payu's master branch
   - pip:
     - git+https://github.com/payu-org/payu.git@master
+    - mule @ git+https://github.com/metomi/mule@cce4b99c7046217b1ec1192118a786636e0d8e54#subdirectory=mule
   - f90nml
   - conda-lock
   - conda-pack

--- a/env-dev.yml
+++ b/env-dev.yml
@@ -16,3 +16,4 @@ dependencies:
   - nco
   - pytest
   - openssh>=8.3
+  - xarray


### PR DESCRIPTION
Mule is required as one of the dependencies for running `um2nc-standalone` (see #34). 

It is also required as one of the dependencies for `update_landuse.py` scripts when running ACCESS-ESM1.5 configs with payu (see https://github.com/ACCESS-NRI/access-esm1.5-configs/blob/dev-historical%2Bconcentrations/scripts/update_landuse.py) 

