### PR TITLE
Dev environment: Use coecms mule rather than pip install

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -90,12 +90,11 @@ jobs:
         run: conda pack
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: payu-dev
+          name: ${{ steps.payu.outputs.name }}
           if-no-files-found: error
-          path: |
-            ${{ steps.payu.outputs.name }}.tar.gz
+          path: ${{ steps.payu.outputs.name }}.tar.gz
 
   deploy:
     runs-on: ubuntu-latest
@@ -106,9 +105,9 @@ jobs:
       NAME: ${{ needs.pack.outputs.name }}
       VERSION: ${{ needs.pack.outputs.version }}
     steps:
-      - uses: actions/download-artifact@v3.0.2
+      - uses: actions/download-artifact@v4
         with:
-          name: payu-dev
+          name: ${{ env.NAME }}
 
       - uses: access-nri/actions/.github/actions/setup-ssh@main
         id: ssh

--- a/env-dev.yml
+++ b/env-dev.yml
@@ -1,13 +1,13 @@
 name: payu-dev
 channels:
   - accessnri
+  - coecms
   - conda-forge
 dependencies:
   - python==3.10
   # Use latest changes from payu's master branch
   - pip:
     - git+https://github.com/payu-org/payu.git@master
-    - mule @ git+https://github.com/metomi/mule@cce4b99c7046217b1ec1192118a786636e0d8e54#subdirectory=mule
   - f90nml
   - conda-lock
   - conda-pack
@@ -17,3 +17,4 @@ dependencies:
   - pytest
   - openssh>=8.3
   - xarray
+  - mule


### PR DESCRIPTION
In #37, `mule` was added to the `payu/dev` environment. There is a conda install of `mule` available on `coecms` channel https://anaconda.org/coecms/mule that can be used instead

This will also prevent a conda-lock issue in deployment environments with pip installs from a directory (see https://github.com/ACCESS-NRI/access-ram-condaenv/issues/3)

Also updated deploy payu/dev workflow to use updated version of upload/download artefact (see #31)