### PR TITLE
Add accessnri::yamanifest to dev environment

### DIFF
--- a/env-dev.yml
+++ b/env-dev.yml
@@ -19,3 +19,4 @@ dependencies:
   - xarray
   - mule
   - um2nc
+  - accessnri::yamanifest


### PR DESCRIPTION
In this PR:
* We add `accessnri::yamanifest` as a first-order dependency to the dev environment, so we can access the `access-nri` flavour of `yamanifest` directly. This is useful for `access-nri/model-config-inputs` to be able to create manifest files. 

Closes #42
